### PR TITLE
Add #include <cstring>

### DIFF
--- a/SudokuSolver.cpp
+++ b/SudokuSolver.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <ctring>
 
 char symbol[] = "123456789";
 


### PR DESCRIPTION
I tried compiling, but it failed on line 387 with `memset`. Maybe 10+ years ago you didn't need to include \<cstring>?

By the way, you may be wondering who I am. Leah sent this to me (along with the story) because she thought I would find it cool. She was right.

![Screenshot 2022-01-21 2 54 43 PM](https://user-images.githubusercontent.com/94580999/150610658-8774c2c6-977f-4142-9643-83bb89f1aea5.png)
